### PR TITLE
[Feature] Update large experience card

### DIFF
--- a/src/components/ExperienceCard.jsx
+++ b/src/components/ExperienceCard.jsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardMedia, Typography, IconButton, Tooltip } from "@
 import { Close } from "@mui/icons-material";
 import PropTypes from 'prop-types';
 import { useNavigate } from "react-router-dom";
-import { deleteEvento } from '../services/api';
+import { deleteEvento } from '../api';
 
 const ExperienceCard = ({ event, removeExperience }) => {
   const navigate = useNavigate();
@@ -71,7 +71,7 @@ const ExperienceCard = ({ event, removeExperience }) => {
           color="primary"
           sx={{ fontWeight: "bold", textTransform: "uppercase", mb: 1 }}
         >
-          {event.dataInicio}
+          {event.dataInicio ? new Date(event.dataInicio).toLocaleDateString() : "Data não informada"}
         </Typography>
         <Typography
           variant="h6"
@@ -98,6 +98,10 @@ const ExperienceCard = ({ event, removeExperience }) => {
         >
           {event.descricao}
         </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Preço: {event.preco === 0 ? "Gratuito" : event.preco ? `R$ ${event.preco.toFixed(2)}` : "Preço não informado"}
+        </Typography>
+        
       </CardContent>
     </Card>
   );
@@ -108,10 +112,11 @@ ExperienceCard.propTypes = {
     id: PropTypes.number.isRequired,
     titulo: PropTypes.string.isRequired,
     endereco: PropTypes.string.isRequired,
-    dataInicio: PropTypes.string.isRequired,
-    imagemUrl: PropTypes.string,
+    dataInicio: PropTypes.string,
+    imagemUrl: PropTypes.string.isRequired,
     descricao: PropTypes.string.isRequired,
     categoria: PropTypes.string.isRequired,
+    preco: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   }).isRequired,
   removeExperience: PropTypes.func.isRequired,
 };

--- a/src/components/LargeExperienceCard.jsx
+++ b/src/components/LargeExperienceCard.jsx
@@ -80,6 +80,7 @@ LargeExperienceCard.propTypes = {
     titulo: PropTypes.string.isRequired,
     endereco: PropTypes.string.isRequired,
     descricao: PropTypes.string.isRequired,
+    categoria: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/LargeExperienceCard.jsx
+++ b/src/components/LargeExperienceCard.jsx
@@ -1,7 +1,23 @@
 import PropTypes from "prop-types";
-import { Card, CardMedia, CardContent, Typography, Button, Box } from "@mui/material";
+import { Card, CardMedia, CardContent, Typography, Button, Box, IconButton, Tooltip } from "@mui/material";
+import { Close } from "@mui/icons-material";
+import { deleteEvento } from '../api';
 
-const LargeExperienceCard = ({ event }) => {
+const LargeExperienceCard = ({ event, removeExperience }) => {
+  const handleRemove = async (e) => {
+    e.stopPropagation();
+
+    if (window.confirm(`Tem certeza que deseja remover "${event.titulo}"?`)) {
+      try {
+        await deleteEvento(event.id);
+        removeExperience(event.categoria, event.id);
+      } catch (error) {
+        console.error('Erro ao remover evento:', error);
+        alert('Ocorreu um erro ao remover o evento. Tente novamente.');
+      }
+    }
+  };
+
   return (
     <Card
       sx={{
@@ -12,8 +28,28 @@ const LargeExperienceCard = ({ event }) => {
         margin: "20px auto",
         borderRadius: "16px",
         boxShadow: "0px 6px 12px rgba(0, 0, 0, 0.1)",
+        position: 'relative',
       }}
     >
+      {/* Botão de Remoção com Tooltip */}
+      <Tooltip title="Remover" arrow>
+        <IconButton 
+          onClick={handleRemove}
+          sx={{ 
+            position: 'absolute', 
+            top: 8, 
+            right: 8, 
+            backgroundColor: 'rgba(255, 255, 255, 0.7)',
+            '&:hover': {
+              backgroundColor: 'rgba(255, 255, 255, 1)',
+            },
+          }}
+          size="small"
+        >
+          <Close fontSize="small" color="action" />
+        </IconButton>
+      </Tooltip>
+
       {/* Imagem */}
       <CardMedia
         component="img"
@@ -82,6 +118,7 @@ LargeExperienceCard.propTypes = {
     descricao: PropTypes.string.isRequired,
     categoria: PropTypes.string.isRequired,
   }).isRequired,
+  removeExperience: PropTypes.func.isRequired,
 };
 
 export default LargeExperienceCard;

--- a/src/components/LargeExperienceCard.jsx
+++ b/src/components/LargeExperienceCard.jsx
@@ -21,8 +21,8 @@ const LargeExperienceCard = ({ event }) => {
           width: "70%", 
           objectFit: "cover" 
         }}
-        image={event.imageUrl}
-        alt={event.title}
+        image={event.imagemUrl}
+        alt={event.titulo}
       />
       
       {/* Conteúdo textual */}
@@ -35,20 +35,27 @@ const LargeExperienceCard = ({ event }) => {
         }}
       >
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          {event.date}
+          {event.dataInicio}
         </Typography>
         <Typography variant="h5" component="div" gutterBottom>
-          {event.title}
+          {event.titulo}
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ marginBottom: "16px" }}>
-          {event.location}
+          {event.endereco}
         </Typography>
         <Typography 
           variant="body1" 
           color="text.primary" 
-          sx={{ flexGrow: 1 }}
+          sx={{ 
+            flexGrow: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+          }}
         >
-          {event.details}
+          {event.descricao}
         </Typography>
 
         {/* Botões sempre no final */}
@@ -67,12 +74,12 @@ const LargeExperienceCard = ({ event }) => {
 
 LargeExperienceCard.propTypes = {
   event: PropTypes.shape({
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired, 
-    imageUrl: PropTypes.string.isRequired,
-    date: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    location: PropTypes.string.isRequired,
-    details: PropTypes.string.isRequired,
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    imagemUrl: PropTypes.string.isRequired,
+    dataInicio: PropTypes.string.isRequired,
+    titulo: PropTypes.string.isRequired,
+    endereco: PropTypes.string.isRequired,
+    descricao: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/components/LargeExperienceCard.jsx
+++ b/src/components/LargeExperienceCard.jsx
@@ -31,7 +31,6 @@ const LargeExperienceCard = ({ event, removeExperience }) => {
         position: 'relative',
       }}
     >
-      {/* Botão de Remoção com Tooltip */}
       <Tooltip title="Remover" arrow>
         <IconButton 
           onClick={handleRemove}
@@ -50,7 +49,6 @@ const LargeExperienceCard = ({ event, removeExperience }) => {
         </IconButton>
       </Tooltip>
 
-      {/* Imagem */}
       <CardMedia
         component="img"
         sx={{ 
@@ -61,7 +59,6 @@ const LargeExperienceCard = ({ event, removeExperience }) => {
         alt={event.titulo}
       />
       
-      {/* Conteúdo textual */}
       <CardContent 
         sx={{ 
           flex: "1", 
@@ -71,7 +68,7 @@ const LargeExperienceCard = ({ event, removeExperience }) => {
         }}
       >
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          {event.dataInicio}
+          {event.dataInicio ? new Date(event.dataInicio).toLocaleDateString() : "Data não informada"}
         </Typography>
         <Typography variant="h5" component="div" gutterBottom>
           {event.titulo}
@@ -94,7 +91,10 @@ const LargeExperienceCard = ({ event, removeExperience }) => {
           {event.descricao}
         </Typography>
 
-        {/* Botões sempre no final */}
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          Preço: {event.preco === 0 ? "Gratuito" : event.preco ? `R$ ${event.preco.toFixed(2)}` : "Preço não informado"}
+        </Typography>
+
         <Box display="flex" justifyContent="space-between">
           <Button variant="outlined" size="small">
             Mais informações
@@ -112,11 +112,12 @@ LargeExperienceCard.propTypes = {
   event: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     imagemUrl: PropTypes.string.isRequired,
-    dataInicio: PropTypes.string.isRequired,
+    dataInicio: PropTypes.string,
     titulo: PropTypes.string.isRequired,
     endereco: PropTypes.string.isRequired,
     descricao: PropTypes.string.isRequired,
     categoria: PropTypes.string.isRequired,
+    preco: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([null])]),
   }).isRequired,
   removeExperience: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description  
This pull request introduces updates to `LargeExperienceCard` and minor changes to `ExperienceCard` to improve their integration with the backend and enhance their usability. The key changes include:

### Component Updates:

* **Layout**:
  - Added text truncation with ellipsis (`text-overflow: ellipsis`) for event descriptions to handle long text gracefully.

* **Object-Based Props**:
  - Updated both components to receive an `event` object as a prop instead of individual attributes.
  - Adjusted the internal logic to access properties like `event.titulo`, `event.descricao`, `event.imagemUrl`, etc.

* **Handling Optional Fields**:
  - Added placeholders for optional fields:
    - `dataInicio`: Displays "Data não informada" if null.
    - `preco`: Displays "Gratuito" if `0`, "Preço não informado" if null, or the formatted price otherwise.

* **Delete Functionality**:
  - Integrated the `deleteEvento` API request to handle event deletion.
  - Added a confirmation dialog before deleting an event.
  - Called the `removeExperience` function to update the frontend state after successful deletion.

* **PropTypes Validation**:
  - Updated `PropTypes` to align with the backend model:
    - `preco` can be `number` or `null`.
    - `dataInicio` is optional and can be `null`.

### Key Features:
  - Improved readability with truncated text for long descriptions.
  - Seamless integration with the backend for event deletion.
  - Proper handling of optional fields with user-friendly placeholders.

These changes ensure a better user experience, improved maintainability, and alignment with the backend model.